### PR TITLE
added a new method "clear" that allows for turning off your end block

### DIFF
--- a/t/000_tests.t
+++ b/t/000_tests.t
@@ -6,7 +6,7 @@
 # Change 1..1 below to 1..last_test_to_print .
 # (It may become useful if the test is moved to ./t subdirectory.)
 
-BEGIN { $| = 1; print "1..3\n"; }
+BEGIN { $| = 1; print "1..4\n"; }
 END {print "not ok 1\n" unless $loaded;}
 use End;
 $loaded = 1;
@@ -32,3 +32,11 @@ foreach my $i (1 .. 9) {
     next;
 }
 print $sum == 45 ? "ok 3\n" : "not ok 3\n";
+
+$sum = 0;
+foreach my $i (1 .. 9) {
+    my $foo = end {$sum += $i};
+    $foo->clear;
+    next;
+}
+print $sum == 0 ? "ok 4\n" : "not ok 4\n";


### PR DESCRIPTION
Hi!

I've been using a very similar module to yours but it isn't on CPAN.  Rather than creating yet another module I thought I would update yours.  The main thing that I wanted to add is the ability to remove an end block.  I wasn't able to come up with a way to clear the end block with the blessed sub ref.  I updated the internal blessed ref to a hash coming from the end sub.  

You might be wondering why I would even add this.  An example might help:

{
    my $end = end {$dbh->rollback};
    ...
    #some complex database manipulations etc.
    ...
    $end->clear;  #everything ran fine
    $dbh->commit;
}

There are other ways of doing what I just did above, but using End in this way allows me to set a time bomb so to speak.  Then if things aren't handled correctly, then I've ensured some sort of clean up event.  If everything is fine, then I diffuse the end block and move on.
